### PR TITLE
Remove trailing line break from dump_schema_information output

### DIFF
--- a/lib/enhanced_mysql_tasks/schema_statements.rb
+++ b/lib/enhanced_mysql_tasks/schema_statements.rb
@@ -8,7 +8,7 @@ module EnhancedMySQLTasks
       sql << ActiveRecord::SchemaMigration.order('version').map { |sm|
         "('#{sm.version}')"
       }.join(",\n")
-      sql << ";\n"
+      sql << ";"
     end
   end
 end

--- a/test/enhanced_mysql_tasks/schema_statements_test.rb
+++ b/test/enhanced_mysql_tasks/schema_statements_test.rb
@@ -14,8 +14,6 @@ class EnhancedMySQLTasks::SchemaStatementsTest < Minitest::Test
     assert_equal "INSERT INTO schema_migrations (version) VALUES
 ('20160101010101'),
 ('20160201010102'),
-('20160301010103');
-
-", ActiveRecord::Base.connection.dump_schema_information
+('20160301010103');", ActiveRecord::Base.connection.dump_schema_information
   end
 end


### PR DESCRIPTION
We do not need any trailing breaks since Rails appends one when dumping schema information to a file.

ref: https://github.com/rails/rails/blob/v4.2.6/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L830
